### PR TITLE
Add MySQL update script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of utilities for processing SQL query results and CSV files.
 - [Features](#features)
   - [CSV to MySQL Tuple](#csv-to-mysql-tuple)
   - [CSV Deduplication](#csv-deduplication)
+  - [CSV to MySQL Update Script](#csv-to-mysql-update-script)
 - [Testing](#testing)
 
 ## Requirements
@@ -114,6 +115,47 @@ Output CSV (`source_deduplicated_20250109_160000.csv`):
 STORE_SKU_ID,PRODUCT_CAT_CODE,ONLINE_STATUS
 C0003001_S_amila008-1,AA28625015001,ONLINE
 C0003001_S_amila008-2,AA28625015001,ONLINE
+```
+
+### CSV to MySQL Update Script
+
+Convert CSV content to MySQL update script, suitable for updating rows in a MySQL table.
+
+#### Technical Implementation
+- Uses Python's built-in `csv.DictReader` for robust CSV parsing
+- Generates MySQL update statements for each row in the CSV
+- Handles column names with spaces intelligently
+- Supports UTF-8 encoded files for international character support
+- Includes error handling for file operations and data processing
+- Provides flexible output options (console or file)
+
+#### Usage
+```bash
+# Basic usage
+python csv_to_mysql.py <csv_file> update_script <table_name>
+
+# Save to output file
+python csv_to_mysql.py <csv_file> update_script <table_name> output/result.txt
+```
+
+#### Example
+
+Input CSV (`source.csv`):
+```csv
+id,name,age
+1,'may',10
+2,'Allen',15
+```
+
+Command:
+```bash
+python csv_to_mysql.py source.csv update_script user
+```
+
+Output:
+```sql
+Update user set name = 'may', age = 10 where id = 1;
+Update user set name = 'Allen', age = 15 where id = 2;
 ```
 
 ## Testing

--- a/tests/test_csv_to_mysql.py
+++ b/tests/test_csv_to_mysql.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import tempfile
-from csv_to_mysql import csv_column_to_mysql_tuple
+from csv_to_mysql import csv_column_to_mysql_tuple, csv_to_mysql_update_script
 
 class TestCsvToMysql(unittest.TestCase):
     def setUp(self):
@@ -78,6 +78,15 @@ class TestCsvToMysql(unittest.TestCase):
         """Test behavior with nonexistent file"""
         result = csv_column_to_mysql_tuple("nonexistent.csv", "PRODUCT_CODE")
         self.assertIsNone(result)
+    
+    def test_update_script_generation(self):
+        """Test CSV to MySQL update script generation"""
+        csv_content = "id,name,age\n1,'may',10\n2,'Allen',15"
+        filepath = self.create_test_csv(csv_content)
+        
+        result = csv_to_mysql_update_script(filepath, "user")
+        expected = "Update user set name = 'may', age = 10 where id = 1;\nUpdate user set name = 'Allen', age = 15 where id = 2;"
+        self.assertEqual(result, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add functionality to convert CSV content to MySQL update script.

* **`csv_to_mysql.py`**
  - Add `csv_to_mysql_update_script` function to generate MySQL update statements.
  - Update `main` function to call `csv_to_mysql_update_script` for generating update scripts.

* **`README.md`**
  - Add usage instructions for generating MySQL update scripts.
  - Include example and technical implementation details for the new feature.

* **`tests/test_csv_to_mysql.py`**
  - Add test case for CSV to MySQL update script generation.
  - Verify the correctness of the generated update scripts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DennisLiuCk/sql-text-helper/pull/1?shareId=f13e235a-e441-4e79-941d-bd479e6587b9).